### PR TITLE
IClojure crash on completing functions for namespace with dots

### DIFF
--- a/src/main/resources/complete.clj
+++ b/src/main/resources/complete.clj
@@ -81,7 +81,10 @@
 (defn resolve-class [sym]
   (try (let [val (resolve sym)]
          (when (class? val) val))
-       (catch ClassNotFoundException e)))
+       (catch ClassNotFoundException e)
+       (catch RuntimeException e
+         (if-not (instance? ClassNotFoundException (.getCause e))
+           (throw e)))))
 
 (defmulti potential-completions
   (fn [prefix ns]


### PR DESCRIPTION
``` clojure
user[1]: (require '[clojure.test :as clt])

user[2]: (clt/<TAB>
clt/deftest-                    clt/join-fixtures               clt/*initial-report-counters*   
clt/assert-predicate            clt/testing-contexts-str        clt/deftest                     
clt/*testing-vars*              clt/is                          clt/testing-vars-str            
clt/get-possibly-unbound-var    clt/testing                     clt/use-fixtures                
clt/try-expr                    clt/run-tests                   clt/do-report                   
clt/test-ns                     clt/*test-out*                  clt/report                      
clt/function?                   clt/file-position               clt/test-all-vars               
clt/run-all-tests               clt/*report-counters*           clt/assert-any                  
clt/inc-report-counter          clt/successful?                 clt/compose-fixtures            
clt/test-var                    clt/are                         clt/*load-tests*                
clt/assert-expr                 clt/with-test-out               clt/set-test                    
clt/with-test                   clt/*stack-trace-depth*         clt/*testing-contexts*          
user[2]: (clt/
```

``` clojure
user[1]: (require 'clojure.test)

user[2]: (clojure.test/<TAB>;;no newline here in the output
Exception in thread "main" java.lang.RuntimeException: java.lang.ClassNotFoundException: clojure.test
    at clojure.lang.Util.runtimeException(Util.java:165)
    at clojure.lang.RT.classForName(RT.java:2017)
    at clojure.lang.Compiler.maybeResolveIn(Compiler.java:6743)
    at clojure.core$ns_resolve.invoke(core.clj:3879)
    at clojure.core$ns_resolve.invoke(core.clj:3876)
    at clojure.core$resolve.invoke(core.clj:3885)
    at complete$resolve_class.invoke(complete.clj:82)
    at complete$eval284$fn__285.invoke(complete.clj:97)
    at clojure.lang.MultiFn.invoke(MultiFn.java:167)
    at complete$completions.invoke(complete.clj:125)
    at complete$completions.invoke(complete.clj:123)
    at clojure.lang.Var.invoke(Var.java:401)
    at com.offbytwo.iclojure.completion.ClojureCompletionWrapper.getCompletionsForString(ClojureCompletionWrapper.java:32)
    at com.offbytwo.iclojure.completion.DefaultCompleter.complete(DefaultCompleter.java:15)
    at com.offbytwo.iclojure.completion.DelegatingCompleter.complete(DelegatingCompleter.java:65)
    at com.iclojure.jline.console.ConsoleReader.complete(ConsoleReader.java:1581)
    at com.iclojure.jline.console.ConsoleReader.readLine(ConsoleReader.java:1290)
    at com.iclojure.jline.console.ConsoleReader.readLine(ConsoleReader.java:1117)
    at com.offbytwo.iclojure.repl.IClojureRepl.readLine(IClojureRepl.java:326)
    at com.offbytwo.iclojure.repl.IClojureRepl.read(IClojureRepl.java:68)
    at com.offbytwo.iclojure.repl.IClojureRepl.loop(IClojureRepl.java:147)
    at com.offbytwo.iclojure.Main.main(Main.java:63)
Caused by: java.lang.ClassNotFoundException: clojure.test
    at java.net.URLClassLoader$1.run(URLClassLoader.java:202)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:190)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:306)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:301)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:247)
    at java.lang.Class.forName0(Native Method)
    at java.lang.Class.forName(Class.java:247)
    at clojure.lang.RT.classForName(RT.java:2013)
    ... 20 more
```

This is with the fix for #18 included (on rev d3841d87626).
